### PR TITLE
refactor: checkbox and label spacing for a cleaner and more consistent look in examples

### DIFF
--- a/apps/www/registry/default/example/checkbox-demo.tsx
+++ b/apps/www/registry/default/example/checkbox-demo.tsx
@@ -4,11 +4,11 @@ import { Checkbox } from "@/registry/default/ui/checkbox"
 
 export default function CheckboxDemo() {
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center">
       <Checkbox id="terms" />
       <label
         htmlFor="terms"
-        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        className="text-sm font-medium leading-none pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
       >
         Accept terms and conditions
       </label>

--- a/apps/www/registry/default/example/checkbox-disabled.tsx
+++ b/apps/www/registry/default/example/checkbox-disabled.tsx
@@ -2,11 +2,11 @@ import { Checkbox } from "@/registry/default/ui/checkbox"
 
 export default function CheckboxDisabled() {
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center">
       <Checkbox id="terms2" disabled />
       <label
         htmlFor="terms2"
-        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        className="text-sm font-medium leading-none pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
       >
         Accept terms and conditions
       </label>

--- a/apps/www/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/default/example/checkbox-form-multiple.tsx
@@ -92,7 +92,7 @@ export default function CheckboxReactHookFormMultiple() {
                     return (
                       <FormItem
                         key={item.id}
-                        className="flex flex-row items-start space-x-3 space-y-0"
+                        className="flex flex-row items-start space-y-0"
                       >
                         <FormControl>
                           <Checkbox
@@ -108,7 +108,7 @@ export default function CheckboxReactHookFormMultiple() {
                             }}
                           />
                         </FormControl>
-                        <FormLabel className="font-normal">
+                        <FormLabel className="font-normal pl-3">
                           {item.label}
                         </FormLabel>
                       </FormItem>

--- a/apps/www/registry/default/example/checkbox-form-single.tsx
+++ b/apps/www/registry/default/example/checkbox-form-single.tsx
@@ -47,14 +47,14 @@ export default function CheckboxReactHookFormSingle() {
           control={form.control}
           name="mobile"
           render={({ field }) => (
-            <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+            <FormItem className="flex flex-row items-start space-y-0 rounded-md border p-4">
               <FormControl>
                 <Checkbox
                   checked={field.value}
                   onCheckedChange={field.onChange}
                 />
               </FormControl>
-              <div className="space-y-1 leading-none">
+              <div className="space-y-1 leading-none pl-3">
                 <FormLabel>
                   Use different settings for my mobile devices
                 </FormLabel>

--- a/apps/www/registry/default/example/checkbox-with-text.tsx
+++ b/apps/www/registry/default/example/checkbox-with-text.tsx
@@ -4,16 +4,16 @@ import { Checkbox } from "@/registry/default/ui/checkbox"
 
 export default function CheckboxWithText() {
   return (
-    <div className="items-top flex space-x-2">
+    <div className="items-top flex">
       <Checkbox id="terms1" />
       <div className="grid gap-1.5 leading-none">
         <label
           htmlFor="terms1"
-          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          className="text-sm font-medium leading-none pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
           Accept terms and conditions
         </label>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm pl-2 text-muted-foreground">
           You agree to our Terms of Service and Privacy Policy.
         </p>
       </div>

--- a/apps/www/registry/new-york/example/checkbox-demo.tsx
+++ b/apps/www/registry/new-york/example/checkbox-demo.tsx
@@ -4,11 +4,11 @@ import { Checkbox } from "@/registry/new-york/ui/checkbox"
 
 export default function CheckboxDemo() {
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center">
       <Checkbox id="terms" />
       <label
         htmlFor="terms"
-        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        className="text-sm font-medium leading-none pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
       >
         Accept terms and conditions
       </label>

--- a/apps/www/registry/new-york/example/checkbox-disabled.tsx
+++ b/apps/www/registry/new-york/example/checkbox-disabled.tsx
@@ -2,11 +2,11 @@ import { Checkbox } from "@/registry/new-york/ui/checkbox"
 
 export default function CheckboxDisabled() {
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center">
       <Checkbox id="terms2" disabled />
       <label
         htmlFor="terms2"
-        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        className="text-sm font-medium leading-none pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
       >
         Accept terms and conditions
       </label>

--- a/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
@@ -92,7 +92,7 @@ export default function CheckboxReactHookFormMultiple() {
                     return (
                       <FormItem
                         key={item.id}
-                        className="flex flex-row items-start space-x-3 space-y-0"
+                        className="flex flex-row items-start space-y-0"
                       >
                         <FormControl>
                           <Checkbox
@@ -108,7 +108,7 @@ export default function CheckboxReactHookFormMultiple() {
                             }}
                           />
                         </FormControl>
-                        <FormLabel className="text-sm font-normal">
+                        <FormLabel className="text-sm font-normal pl-3">
                           {item.label}
                         </FormLabel>
                       </FormItem>

--- a/apps/www/registry/new-york/example/checkbox-form-single.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-single.tsx
@@ -47,14 +47,14 @@ export default function CheckboxReactHookFormSingle() {
           control={form.control}
           name="mobile"
           render={({ field }) => (
-            <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4 shadow">
+            <FormItem className="flex flex-row items-start space-y-0 rounded-md border p-4 shadow">
               <FormControl>
                 <Checkbox
                   checked={field.value}
                   onCheckedChange={field.onChange}
                 />
               </FormControl>
-              <div className="space-y-1 leading-none">
+              <div className="space-y-1 leading-none pl-3">
                 <FormLabel>
                   Use different settings for my mobile devices
                 </FormLabel>

--- a/apps/www/registry/new-york/example/checkbox-with-text.tsx
+++ b/apps/www/registry/new-york/example/checkbox-with-text.tsx
@@ -4,16 +4,16 @@ import { Checkbox } from "@/registry/new-york/ui/checkbox"
 
 export default function CheckboxWithText() {
   return (
-    <div className="items-top flex space-x-2">
+    <div className="items-top flex">
       <Checkbox id="terms1" />
       <div className="grid gap-1.5 leading-none">
         <label
           htmlFor="terms1"
-          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          className="text-sm font-medium leading-none pl-2 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
         >
           Accept terms and conditions
         </label>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm pl-2 text-muted-foreground">
           You agree to our Terms of Service and Privacy Policy.
         </p>
       </div>


### PR DESCRIPTION
## Description

This commit improves the spacing of checkboxes and labels in examples. Instead of using `space-x` classes on the parent, it adds `pl` classes to the labels, resulting in a cleaner and more consistent layout. This change enhances the default user experience and maintains consistency.

### Motivation
issue #2861

### Changes Made

- Replaced `space-x` classes with `pl` classes on labels for better spacing.
- Improved overall visual consistency for checkbox and label elements.

### Impact

- Provides a more intuitive default user experience.
- Enhances consistency for projects using shadcn/ui.
